### PR TITLE
Fix 422 error on approval when optional fields are null, auto-populate zip/county from geocoding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,165 +6,88 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: actions/checkout@v2
-        id: code-checkout
+      - name: Check out code 🛒
+        uses: actions/checkout@v6
 
-      - name: Validate composer.json and composer.lock
-        id: composer-validate
-        run: composer validate
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
+      - name: Setup PHP 🐫
+        uses: shivammathur/setup-php@v2
         with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+          php-version: 8.2
 
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
-        id: install-dependencies
-        uses: php-actions/composer@v5
-        with:
-          php_version: 8.0
-          args: --prefer-dist --no-progress --no-suggest
+        run: composer install --prefer-dist --no-progress
 
       - name: PHP Unit Test
-        id: php-unit-test
-        uses: php-actions/phpunit@v3
-        with:
-          php_version: 8.0.27
-          version: 9.5.21
+        run: vendor/bin/phpunit
 
-      - uses: act10ns/slack@v1
-        with:
-          status: ${{ job.status }}
-          steps: ${{ toJson(steps) }}
-          channel: '#wordpress-bmlt-workflow'
-        if: failure()
+#      - uses: act10ns/slack@v1
+#        with:
+#          status: ${{ job.status }}
+#          steps: ${{ toJson(steps) }}
+#          channel: '#wordpress-bmlt-workflow'
+#        if: failure()
 
-  deploy-bmlt-workflow-latest:
-    runs-on: ubuntu-latest
+  package:
+    runs-on: ubuntu-24.04
+    needs: [ tests ]
     permissions:
-      id-token: write
       contents: write
     env:
-      WORDPRESS_USERNAME: ${{ secrets.BMLTWF_WORDPRESS_USERNAME }}
-      WORDPRESS_PASSWORD: ${{ secrets.BMLTWF_WORDPRESS_PASSWORD }}
       BUILD_DIR: build
-      DIST_DIR_S3: dist/s3
       DIST_DIR_GITHUB: dist/github
       GITHUB_RELEASE_FILENAME: bmlt-workflow.zip
-      S3_KEY: bmlt-workflow
       PLUGIN: bmlt-workflow
       MAINFILE: bmlt-workflow.php
     steps:
-      - uses: actions/checkout@v2
-        id: code-checkout
+      - name: Check out code 🛒
+        uses: actions/checkout@v4
 
-      - name: Validate composer.json and composer.lock
-        id: composer-validate
-        run: composer validate
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
+      - name: Setup PHP 🐫
+        uses: shivammathur/setup-php@v2
         with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+          php-version: 8.2
 
-      - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
-        id: install-dependencies
-        run: composer install --no-dev --prefer-dist --no-progress --no-suggest
-
-      - name: Prepare zip file
+      - name: Build package 🔧
         run: |
-          export ZIP_FILENAME=${S3_KEY}-build${GITHUB_RUN_NUMBER}-${GITHUB_SHA}.zip
-          echo "ZIP_FILENAME=${ZIP_FILENAME}" >> $GITHUB_ENV
-          echo "GITHUB_RELEASE_FILENAME=${GITHUB_RELEASE_FILENAME}" >> $GITHUB_ENV
-          echo "GITHUB_RELEASE_PATH=${DIST_DIR_GITHUB}/${GITHUB_RELEASE_FILENAME}" >> $GITHUB_ENV
-          zip -r $ZIP_FILENAME ./ -x "/.git*" -x "*.editorconfig*" -x "/vendor*" -x "/mockoon/*" -x "composer.*" -x "*.github*" -x "/assets*" -x "*.gitattributes" -x "/node_modules/*" -x "/tests/*" -x ".userdetails.sh" -x ".phpunit.result.cache" -x "*.DS_Store*" -x "Dockerfile" -x "patchwork.json" -x "/.phpunit.cache*" -x "/docker/*" -x "/.vscode*" -x "phpunit.xml" -x ".testcaferc.js" -x "docker-compose.yml" -x "package.json" -x "package-lock.json" -x "phpunit.xml.orig" -x "config_phpunit.php"
-          mkdir $BUILD_DIR && mv $ZIP_FILENAME $BUILD_DIR/
-          mkdir -p $DIST_DIR_S3 && cp $BUILD_DIR/$ZIP_FILENAME $DIST_DIR_S3/$ZIP_FILENAME
+          composer install --no-dev --prefer-dist --no-progress
+          export ZIP_FILENAME=${PLUGIN}-${GITHUB_REF##*/}.zip
+          zip -r $ZIP_FILENAME ./ -x "/.git*" -x "*.editorconfig*" -x "/vendor*" -x "/mockoon/*" -x "composer.*" -x "*.github*" -x "/assets*" -x "*.gitattributes" -x "/node_modules/*" -x "/tests/*" -x ".userdetails.sh" -x ".phpunit.result.cache" -x "*.DS_Store*" -x "Dockerfile" -x "patchwork.json" -x "/.phpunit.cache*" -x "/docker/*" -x "/.vscode*" -x "phpunit.xml" -x ".testcaferc.js"  -x ".eslintrc.js" -x "docker-compose.yml" -x "package.json" -x "package-lock.json" -x "phpunit.xml.orig" -x "phpunit.xml.bak" -x "config_phpunit.php"
+          mkdir -p $BUILD_DIR && mv $ZIP_FILENAME $BUILD_DIR/
           mkdir -p $DIST_DIR_GITHUB && cp $BUILD_DIR/$ZIP_FILENAME $DIST_DIR_GITHUB/$GITHUB_RELEASE_FILENAME
-          curl -LO https://raw.githubusercontent.com/bmlt-enabled/bmlt-wordpress-deploy/master/deploy-wordpress.sh
-          chmod +x deploy-wordpress.sh
-          curl -sLO https://raw.githubusercontent.com/bmlt-enabled/release-notes-tool/master/gh-release-notes.sh
+          echo "ARTIFACT_PATH=$DIST_DIR_GITHUB/$GITHUB_RELEASE_FILENAME" >> $GITHUB_ENV
+          RELEASE_TYPE=$(if [[ "$GITHUB_REF_NAME" =~ "beta" ]]; then echo "true"; else echo "false"; fi)
+          echo "RELEASE_TYPE=${RELEASE_TYPE}" >> $GITHUB_ENV
+
+      - name: Generate Release Notes 📝
+        run: |
+          curl -sLO https://raw.githubusercontent.com/bmlt-enabled/release-notes-tool/main/gh-release-notes.sh
           chmod +x gh-release-notes.sh
           ./gh-release-notes.sh CHANGELOG.md "##"
 
-      - name: Prepare artifact metadata
-        id: prepare_artifact_metadata
+      - name: Create Release 🎉
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ${{ env.ARTIFACT_PATH }}
+          bodyFile: "changelog.txt"
+          prerelease: ${{ env.RELEASE_TYPE }}
+
+      - name: Wordpress Release ⛴
+        if: "!contains(github.ref, 'beta')"
+        env:
+          WORDPRESS_USERNAME: ${{ secrets.BMLTWF_WORDPRESS_USERNAME }}
+          WORDPRESS_PASSWORD: ${{ secrets.BMLTWF_WORDPRESS_PASSWORD }}
         run: |
-          echo ::set-output name=ARTIFACT_PATH::./${GITHUB_RELEASE_PATH}
-          echo ::set-output name=ARTIFACT_NAME::${GITHUB_RELEASE_FILENAME}
-
-      - name: Release beta
-        if: contains(github.ref, 'beta')
-        id: beta_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          prerelease: true
-          draft: false
-
-      - name: Upload Beta Asset
-        if: contains(github.ref, 'beta')
-        id: beta-release-asset-wp
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.beta_release.outputs.upload_url }}
-          asset_path: ${{ steps.prepare_artifact_metadata.outputs.ARTIFACT_PATH }}
-          asset_name: ${{ steps.prepare_artifact_metadata.outputs.ARTIFACT_NAME }}
-          asset_content_type: application/zip
-
-      - name: Release stable
-        if: "!contains(github.ref, 'beta')"
-        id: stable_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body_path: "changelog.txt"
-          prerelease: false
-          draft: false
-
-      - name: Upload Stable Asset WP
-        if: "!contains(github.ref, 'beta')"
-        id: stable-release-asset-wp
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.stable_release.outputs.upload_url }}
-          asset_path: ${{ steps.prepare_artifact_metadata.outputs.ARTIFACT_PATH }}
-          asset_name: ${{ steps.prepare_artifact_metadata.outputs.ARTIFACT_NAME }}
-          asset_content_type: application/zip
-
-      - name: Publish Release to WP
-        if: "!contains(github.ref, 'beta')"
-        id: publish-release-wp
-        run: |
+          curl -LO https://raw.githubusercontent.com/bmlt-enabled/bmlt-wordpress-deploy/main/deploy-wordpress.sh
+          chmod +x deploy-wordpress.sh
           ./deploy-wordpress.sh
 
-      - uses: act10ns/slack@v1
-        with:
-          status: ${{ job.status }}
-          steps: ${{ toJson(steps) }}
-          channel: '#wordpress-bmlt-workflow'
-        if: failure()
+#      - uses: act10ns/slack@v1
+#        with:
+#          status: ${{ job.status }}
+#          steps: ${{ toJson(steps) }}
+#          channel: '#wordpress-bmlt-workflow'
+#        if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,12 @@ jobs:
       - name: PHP Unit Test
         run: vendor/bin/phpunit
 
-#      - uses: act10ns/slack@v1
-#        with:
-#          status: ${{ job.status }}
-#          steps: ${{ toJson(steps) }}
-#          channel: '#wordpress-bmlt-workflow'
-#        if: failure()
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#wordpress-bmlt-workflow'
+        if: failure()
 
   package:
     runs-on: ubuntu-24.04
@@ -85,9 +85,9 @@ jobs:
           chmod +x deploy-wordpress.sh
           ./deploy-wordpress.sh
 
-#      - uses: act10ns/slack@v1
-#        with:
-#          status: ${{ job.status }}
-#          steps: ${{ toJson(steps) }}
-#          channel: '#wordpress-bmlt-workflow'
-#        if: failure()
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#wordpress-bmlt-workflow'
+        if: failure()

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/phpunit/bootstrap.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/phpunit/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
   <php>
     <ini name="display_errors" value="true"/>
   </php>
@@ -8,9 +8,9 @@
       <directory>tests/phpunit</directory>
     </testsuite>
   </testsuites>
-  <coverage>
+  <source>
     <include>
       <directory suffix=".php">src</directory>
     </include>
-  </coverage>
+  </source>
 </phpunit>

--- a/phpunit.xml.bak
+++ b/phpunit.xml.bak
@@ -1,30 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
-         bootstrap="tests/phpunit/bootstrap.php"
-         cacheResultFile=".phpunit.cache/test-results"
-         executionOrder="depends,defects"
-         forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         convertDeprecationsToExceptions="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         verbose="true">
-<php>
-         <ini name="display_errors" value="true"/>
-    </php>
-    <testsuites>
-        <testsuite name="default">
-            <directory>tests/phpunit</directory>
-        </testsuite>
-    </testsuites>
-
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+<phpunit bootstrap="tests/phpunit/bootstrap.php">
+  <php>
+    <ini name="display_errors" value="true"/>
+  </php>
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
 </phpunit>

--- a/src/BMLT/Integration.php
+++ b/src/BMLT/Integration.php
@@ -736,6 +736,12 @@ class Integration
 
         foreach ($meeting as $key => $value) {
             if (array_key_exists($key, $allowed_keys)) {
+                // null is valid for any optional field - pass through without type checking
+                if ($value === null) {
+                    $filtered_meeting[$key] = $value;
+                    continue;
+                }
+
                 $expected_type = $allowed_keys[$key];
                 $valid = false;
 

--- a/src/REST/Handlers/SubmissionsHandler.php
+++ b/src/REST/Handlers/SubmissionsHandler.php
@@ -621,16 +621,18 @@ class SubmissionsHandler
 
                 $locfields = array("location_street", "location_municipality", "location_province", "location_postal_code_1", "location_sub_province", "location_nation");
 
+                $location_changed = false;
                 foreach ($locfields as $field) {
                     if (!empty($change[$field])) {
                         $bmlt_meeting[$field] = $change[$field];
+                        $location_changed = true;
                     }
                 }
 
-                if ((!array_key_exists('latitude',$change))&&(!array_key_exists('longitude',$change)))
+                if ($location_changed && (!array_key_exists('latitude',$change))&&(!array_key_exists('longitude',$change)))
                 {
                     if ($this->bmlt_integration->isAutoGeocodingEnabled('auto')) {
-                        $this->debug_log("auto geocoding enabled, performing geolocate");
+                        $this->debug_log("auto geocoding enabled and location changed, performing geolocate");
                         $latlng = $this->do_geolocate($bmlt_meeting);
                         if (is_wp_error($latlng)) {
                             return $latlng;
@@ -646,33 +648,12 @@ class SubmissionsHandler
                             $change['location_sub_province'] = $latlng['location_sub_province'];
                         }
                     } else {
+                        // auto geocoding disabled and location changed - only update lat/long if meeting has none
+                        $latexists = (array_key_exists('latitude',$bmlt_meeting)) && $bmlt_meeting['latitude'] != 0;
+                        $longexists = (array_key_exists('longitude',$bmlt_meeting)) && $bmlt_meeting['longitude'] != 0;
 
-                        $latexists = false;
-                        $longexists = false;
-
-                        if ((array_key_exists('latitude',$bmlt_meeting)) && $bmlt_meeting['latitude'] != 0)
-                        {
-                            $this->debug_log("latitude found");
-                            $latexists = true;
-                        }
-                        else
-                        {
-                            $this->debug_log("latitude not found");
-                        }
-                        if ((array_key_exists('longitude',$bmlt_meeting)) && $bmlt_meeting['longitude'] != 0)
-                        {
-                            $this->debug_log("longitude found");
-                            $longexists = true;
-                        }
-                        else
-                        {
-                            $this->debug_log("longitude not found");
-                        }
-
-                        // update this only if we have no meeting lat/long already set
                         if (!$latexists && !$longexists) {
                             $this->debug_log("blank lat/long - updating to defaults");
-        
                             $latlng = $this->bmlt_integration->getDefaultLatLong();
                             $change['latitude'] = $latlng['latitude'];
                             $change['longitude'] = $latlng['longitude'];

--- a/src/REST/Handlers/SubmissionsHandler.php
+++ b/src/REST/Handlers/SubmissionsHandler.php
@@ -431,6 +431,24 @@ class SubmissionsHandler
         $latlng['longitude'] = $location['results'][0]['geometry']['location']['lng'];
         $this->debug_log("GMAPS location lookup returns = " .  $latlng['latitude']  . " " . $latlng['longitude']);
 
+        $address_components = $location['results'][0]['address_components'] ?? [];
+        if ($this->bmlt_integration->isAutoGeocodingEnabled('zip')) {
+            foreach ($address_components as $component) {
+                if (in_array('postal_code', $component['types'])) {
+                    $latlng['location_postal_code_1'] = $component['short_name'];
+                    break;
+                }
+            }
+        }
+        if ($this->bmlt_integration->isAutoGeocodingEnabled('county')) {
+            foreach ($address_components as $component) {
+                if (in_array('administrative_area_level_2', $component['types'])) {
+                    $latlng['location_sub_province'] = $component['short_name'];
+                    break;
+                }
+            }
+        }
+
         return $latlng;
     }
 
@@ -551,6 +569,12 @@ class SubmissionsHandler
                         }
                         $change['latitude'] = $latlng['latitude'];
                         $change['longitude'] = $latlng['longitude'];
+                        if (isset($latlng['location_postal_code_1'])) {
+                            $change['location_postal_code_1'] = $latlng['location_postal_code_1'];
+                        }
+                        if (isset($latlng['location_sub_province'])) {
+                            $change['location_sub_province'] = $latlng['location_sub_province'];
+                        }
                     } else {
                         $latlng = $this->bmlt_integration->getDefaultLatLong();
                         $change['latitude'] = $latlng['latitude'];
@@ -615,6 +639,12 @@ class SubmissionsHandler
                         // add the new geo to the original change
                         $change['latitude'] = $latlng['latitude'];
                         $change['longitude'] = $latlng['longitude'];
+                        if (isset($latlng['location_postal_code_1'])) {
+                            $change['location_postal_code_1'] = $latlng['location_postal_code_1'];
+                        }
+                        if (isset($latlng['location_sub_province'])) {
+                            $change['location_sub_province'] = $latlng['location_sub_province'];
+                        }
                     } else {
 
                         $latexists = false;

--- a/tests/phpunit/src/BMLT/IntegrationTest.php
+++ b/tests/phpunit/src/BMLT/IntegrationTest.php
@@ -1103,4 +1103,50 @@ EOD;
 		$this->assertEquals(['CA', 'NY', 'TX'], $result2);
 		$this->assertEquals(1, $fetchCount, 'Should not fetch from server again');
 	}
+
+    /**
+     * @covers bmltwf\BMLT\Integration::validateMeetingData
+     * @covers bmltwf\BMLT\Integration::updateMeeting
+     */
+    public function test_validateMeetingData_passes_null_optional_fields_without_type_error(): void
+    {
+        $capturedBody = null;
+
+        Functions\when('\wp_remote_request')->alias(function ($url, $args) use (&$capturedBody) {
+            if (isset($args['body'])) {
+                $capturedBody = $args['body'];
+            }
+            return ['response' => ['code' => 204]];
+        });
+
+        Functions\when('\wp_remote_retrieve_body')->justReturn($this->formats);
+        Functions\when('wp_remote_retrieve_response_code')->justReturn(204);
+
+        $meeting = array(
+            "id" => 123,
+            "name" => "Test Meeting",
+            "location_street" => null,
+            "location_sub_province" => null,
+            "comments" => null,
+            "day" => "2",
+            "serviceBodyId" => "1050",
+            "formatIds" => [7],
+            "venueType" => "1",
+            "published" => "1",
+        );
+
+        $integration = new Integration(true, "3.0.0", "token", time() + 2000);
+        $result = $integration->updateMeeting($meeting);
+
+        $this->assertNotInstanceOf(WP_Error::class, $result, "updateMeeting should not return WP_Error for null optional fields");
+        $this->assertNotNull($capturedBody, "Request body was not captured");
+        $decodedBody = json_decode($capturedBody, true);
+        $this->assertIsArray($decodedBody);
+        $this->assertArrayHasKey('location_street', $decodedBody, "null location_street should be included in request");
+        $this->assertNull($decodedBody['location_street'], "location_street should remain null");
+        $this->assertArrayHasKey('comments', $decodedBody, "null comments should be included in request");
+        $this->assertNull($decodedBody['comments'], "comments should remain null");
+        $this->assertArrayHasKey('location_sub_province', $decodedBody, "null location_sub_province should be included in request");
+        $this->assertNull($decodedBody['location_sub_province'], "location_sub_province should remain null");
+    }
 }

--- a/tests/phpunit/src/REST/Handlers/SubmissionsHandlerTest.php
+++ b/tests/phpunit/src/REST/Handlers/SubmissionsHandlerTest.php
@@ -2247,5 +2247,230 @@ Line: $errorLine
         $this->assertEquals('', $captured_update_data['virtual_meeting_link']);
     }
 
+    /**
+     * @covers bmltwf\REST\Handlers\SubmissionsHandler::approve_submission_handler
+     */
+    public function test_approve_new_meeting_geocoding_populates_zip_and_county_from_address_components(): void
+    {
+        $test_submission_id = '14';
+        $request = $this->generate_approve_request($test_submission_id, '');
+
+        $row = array(
+            'change_id' => $test_submission_id,
+            'submission_time' => '2022-03-23 09:25:53',
+            'change_time' => '0000-00-00 00:00:00',
+            'changed_by' => 'NULL',
+            'change_made' => 'NULL',
+            'submitter_name' => 'test submitter',
+            'submission_type' => 'reason_new',
+            'submitter_email' => 'a@a.com',
+            'id' => 3563,
+            'serviceBodyId' => '4',
+            // No latitude/longitude — triggers geocoding
+            'changes_requested' => '{"name":"New Meeting","location_street":"123 Main St","location_municipality":"Springfield","day":3,"startTime":"19:00:00","duration":"01:00:00","serviceBodyId":"4","formatIds":[1]}',
+        );
+
+        global $wpdb;
+        $wpdb = Mockery::mock('wpdb');
+        $wpdb->shouldReceive([
+            'prepare' => 'nothing',
+            'get_row' => $row,
+            'get_results' => 'nothing'
+        ]);
+        $wpdb->prefix = "";
+
+        Functions\when('\get_option')->justReturn("success");
+
+        $formats = '[ { "@attributes": { "sequence_index": "0" }, "key_string": "B", "name_string": "Beginners", "lang": "en", "id": "1", "world_id": "BEG" }]';
+        $bmlt = \Mockery::mock('Integration');
+        $bmlt->shouldReceive('getMeeting')->andReturn(json_decode($this->meeting, true));
+        $bmlt->shouldReceive('getMeetingFormats')->andReturn(json_decode($formats, true));
+        $bmlt->shouldReceive('getServiceBodies')->andReturn(array("1" => array("name" => "test"), "3" => array("name" => "test"), "4" => array("name" => "test")));
+        $bmlt->shouldReceive('isAutoGeocodingEnabled')->andReturn(true);
+        $bmlt->shouldReceive('geolocateAddress')->andReturn([
+            'results' => [
+                [
+                    'geometry' => ['location' => ['lat' => 40.7127753, 'lng' => -74.0059728]],
+                    'address_components' => [
+                        ['long_name' => '10007', 'short_name' => '10007', 'types' => ['postal_code']],
+                        ['long_name' => 'New York County', 'short_name' => 'New York County', 'types' => ['administrative_area_level_2', 'political']],
+                    ]
+                ]
+            ]
+        ]);
+
+        $captured_meeting = null;
+        $bmlt->shouldReceive('createMeeting')
+            ->with(Mockery::capture($captured_meeting))
+            ->andReturn(true);
+
+        Functions\when('\wp_remote_retrieve_cookies')->justReturn(array("0" => "1"));
+
+        $handlers = new SubmissionsHandler($bmlt);
+
+        $user = new SubmissionsHandlerTest_my_wp_user(1, 'username');
+        Functions\when('\wp_get_current_user')->justReturn($user);
+        Functions\when('\is_wp_error')->justReturn(false);
+        Functions\when('\wp_mail')->justReturn('true');
+        Functions\when('\current_user_can')->justReturn('false');
+        Functions\when('\wp_is_json_media_type')->justReturn('true');
+
+        $response = $handlers->approve_submission_handler($request);
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertEquals(200, $response->get_status());
+
+        $this->assertNotNull($captured_meeting, "createMeeting was not called");
+        $this->assertArrayHasKey('latitude', $captured_meeting, "latitude should be set from geocoding");
+        $this->assertArrayHasKey('longitude', $captured_meeting, "longitude should be set from geocoding");
+        $this->assertArrayHasKey('location_postal_code_1', $captured_meeting, "zip should be populated from geocoding address_components");
+        $this->assertEquals('10007', $captured_meeting['location_postal_code_1']);
+        $this->assertArrayHasKey('location_sub_province', $captured_meeting, "county should be populated from geocoding address_components");
+        $this->assertEquals('New York County', $captured_meeting['location_sub_province']);
+    }
+
+    /**
+     * @covers bmltwf\REST\Handlers\SubmissionsHandler::approve_submission_handler
+     */
+    public function test_approve_change_meeting_does_not_add_geocoords_when_no_location_changed(): void
+    {
+        $test_submission_id = '14';
+        $request = $this->generate_approve_request($test_submission_id, '');
+
+        // No location fields in changes_requested
+        $row = array(
+            'change_id' => $test_submission_id,
+            'submission_time' => '2022-03-23 09:25:53',
+            'change_time' => '0000-00-00 00:00:00',
+            'changed_by' => 'NULL',
+            'change_made' => 'NULL',
+            'submitter_name' => 'test submitter',
+            'submission_type' => 'reason_change',
+            'submitter_email' => 'a@a.com',
+            'id' => 3563,
+            'serviceBodyId' => '4',
+            'changes_requested' => '{"name":"Updated Name Only","day":5,"formatIds":[1,4]}',
+        );
+
+        global $wpdb;
+        $wpdb = Mockery::mock('wpdb');
+        $wpdb->shouldReceive([
+            'prepare' => 'nothing',
+            'get_row' => $row,
+            'get_results' => 'nothing'
+        ]);
+        $wpdb->prefix = "";
+
+        Functions\when('\get_option')->justReturn("success");
+
+        $bmlt_input = '';
+        $stub_bmltv3 = $this->stub_bmltv3($this->meeting, $bmlt_input);
+
+        $captured_change = null;
+        $stub_bmltv3->shouldReceive('updateMeeting')
+            ->with(Mockery::capture($captured_change))
+            ->andReturn(true);
+
+        $handlers = new SubmissionsHandler($stub_bmltv3);
+
+        $user = new SubmissionsHandlerTest_my_wp_user(1, 'username');
+        Functions\when('\wp_get_current_user')->justReturn($user);
+        Functions\when('\is_wp_error')->justReturn(false);
+        Functions\when('\wp_mail')->justReturn('true');
+        Functions\when('\current_user_can')->justReturn('false');
+        Functions\when('\wp_is_json_media_type')->justReturn('true');
+
+        $response = $handlers->approve_submission_handler($request);
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertEquals(200, $response->get_status());
+
+        $this->assertNotNull($captured_change, "updateMeeting was not called");
+        // With no location fields changed, geocoding should not be triggered and lat/lng should not be added
+        $this->assertArrayNotHasKey('latitude', $captured_change, "latitude should not be added when no location fields changed");
+        $this->assertArrayNotHasKey('longitude', $captured_change, "longitude should not be added when no location fields changed");
+    }
+
+    /**
+     * @covers bmltwf\REST\Handlers\SubmissionsHandler::approve_submission_handler
+     */
+    public function test_approve_change_meeting_geocodes_and_populates_zip_county_when_location_changed(): void
+    {
+        $test_submission_id = '14';
+        $request = $this->generate_approve_request($test_submission_id, '');
+
+        // location_street is changed — triggers geocoding
+        $row = array(
+            'change_id' => $test_submission_id,
+            'submission_time' => '2022-03-23 09:25:53',
+            'change_time' => '0000-00-00 00:00:00',
+            'changed_by' => 'NULL',
+            'change_made' => 'NULL',
+            'submitter_name' => 'test submitter',
+            'submission_type' => 'reason_change',
+            'submitter_email' => 'a@a.com',
+            'id' => 3563,
+            'serviceBodyId' => '4',
+            'changes_requested' => '{"name":"Updated Meeting","location_street":"456 New Street","day":5,"formatIds":[1]}',
+        );
+
+        global $wpdb;
+        $wpdb = Mockery::mock('wpdb');
+        $wpdb->shouldReceive([
+            'prepare' => 'nothing',
+            'get_row' => $row,
+            'get_results' => 'nothing'
+        ]);
+        $wpdb->prefix = "";
+
+        Functions\when('\get_option')->justReturn("success");
+
+        $formats = '[ { "@attributes": { "sequence_index": "0" }, "key_string": "B", "name_string": "Beginners", "lang": "en", "id": "1", "world_id": "BEG" }]';
+        $bmlt = \Mockery::mock('Integration');
+        $bmlt->shouldReceive('getMeeting')->andReturn(json_decode($this->meeting, true));
+        $bmlt->shouldReceive('getMeetingFormats')->andReturn(json_decode($formats, true));
+        $bmlt->shouldReceive('getServiceBodies')->andReturn(array("1" => array("name" => "test"), "3" => array("name" => "test"), "4" => array("name" => "test")));
+        $bmlt->shouldReceive('isAutoGeocodingEnabled')->andReturn(true);
+        $bmlt->shouldReceive('geolocateAddress')->andReturn([
+            'results' => [
+                [
+                    'geometry' => ['location' => ['lat' => 37.7749, 'lng' => -122.4194]],
+                    'address_components' => [
+                        ['long_name' => '94102', 'short_name' => '94102', 'types' => ['postal_code']],
+                        ['long_name' => 'San Francisco County', 'short_name' => 'San Francisco County', 'types' => ['administrative_area_level_2', 'political']],
+                    ]
+                ]
+            ]
+        ]);
+
+        $captured_change = null;
+        $bmlt->shouldReceive('updateMeeting')
+            ->with(Mockery::capture($captured_change))
+            ->andReturn(true);
+
+        Functions\when('\wp_remote_retrieve_cookies')->justReturn(array("0" => "1"));
+
+        $handlers = new SubmissionsHandler($bmlt);
+
+        $user = new SubmissionsHandlerTest_my_wp_user(1, 'username');
+        Functions\when('\wp_get_current_user')->justReturn($user);
+        Functions\when('\is_wp_error')->justReturn(false);
+        Functions\when('\wp_mail')->justReturn('true');
+        Functions\when('\current_user_can')->justReturn('false');
+        Functions\when('\wp_is_json_media_type')->justReturn('true');
+
+        $response = $handlers->approve_submission_handler($request);
+        $this->assertInstanceOf(WP_REST_Response::class, $response);
+        $this->assertEquals(200, $response->get_status());
+
+        $this->assertNotNull($captured_change, "updateMeeting was not called");
+        $this->assertArrayHasKey('latitude', $captured_change, "latitude should be added from geocoding when location changed");
+        $this->assertArrayHasKey('longitude', $captured_change, "longitude should be added from geocoding when location changed");
+        $this->assertEquals(37.7749, $captured_change['latitude']);
+        $this->assertEquals(-122.4194, $captured_change['longitude']);
+        $this->assertArrayHasKey('location_postal_code_1', $captured_change, "zip should be populated from geocoding address_components");
+        $this->assertEquals('94102', $captured_change['location_postal_code_1']);
+        $this->assertArrayHasKey('location_sub_province', $captured_change, "county should be populated from geocoding address_components");
+        $this->assertEquals('San Francisco County', $captured_change['location_sub_province']);
+    }
+
 
 }


### PR DESCRIPTION
  - Fix 422 error on approval when optional fields are null:  validateMeetingData was rejecting null values for optional string fields (e.g. location_sub_province), causing a 422  when approving new meeting submissions where those fields were hidden or not collected by the form. Null values now pass through type validation unchanged.

  - Auto-populate zip/county from geocoding on approval (closes #221):  Brings server-side geolocation (do_geolocate) in line with the admin JS: when zip or county auto-geocoding  is enabled in the BMLT server config, those fields are now extracted from the Google Maps response and applied to the meeting on approval. Previously, meetings approved via   the plugin would land in BMLT with blank zip/county because the BMLT API (unlike the BMLT admin UI) does not trigger auto-calculation on create/update.

  - Only re-geolocate on reason_change when a location field actually changed (closes #165, closes #223): Previously, approving any meeting change would always re-geolocate and  overwrite lat/lng even if only time, format, or other non-location fields changed. This clobbered manually-adjusted map pins set in the BMLT admin. Geocoding is now skipped  unless at least one location field (street, city, state, zip, county, nation) is included in the submission.